### PR TITLE
Add support for task lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Will output:
 </pre>
 ```
 
-To enable the styling you will need to add the following to your Sass file:
+### Additional styles
+
+To enable the styling for inline code, block code and checkboxes in task lists, add the following to your Sass file:
 
 ```scss
 @import "govuk-markdown/x-govuk/all";

--- a/index.js
+++ b/index.js
@@ -55,6 +55,11 @@ module.exports = class GovukHTMLRenderer extends Renderer {
     return `<${element} class="govuk-list govuk-list--${modifier}">${body}</${element}>`
   }
 
+  // Checkbox
+  checkbox (checked) {
+    return `<span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox"${checked ? ' checked' : ''} disabled><span class="x-govuk-checkbox__pseudo"></span></span>`
+  }
+
   // Section break
   hr () {
     return '<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">'

--- a/tests/index.mjs
+++ b/tests/index.mjs
@@ -61,6 +61,11 @@ test('Renders unordered list', t => {
   t.is(result, '<ul class="govuk-list govuk-list--bullet"><li>Item</li>\n<li>Item</li>\n</ul>')
 })
 
+test('Renders task list', t => {
+  const result = marked('* [ ] Item\n* [x] Item')
+  t.is(result, '<ul class="govuk-list govuk-list--bullet"><li><span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox" disabled><span class="x-govuk-checkbox__pseudo"></span></span>Item</li>\n<li><span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox" checked disabled><span class="x-govuk-checkbox__pseudo"></span></span>Item</li>\n</ul>')
+})
+
 test('Renders section break', t => {
   const result = marked('***')
   t.is(result, '<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">')

--- a/x-govuk/_all.scss
+++ b/x-govuk/_all.scss
@@ -1,1 +1,2 @@
+@import "checkbox/checkbox";
 @import "code/code";

--- a/x-govuk/checkbox/_checkbox.scss
+++ b/x-govuk/checkbox/_checkbox.scss
@@ -1,0 +1,64 @@
+$touch-target-size: 28px;
+$checkbox-size: 24px;
+$input-offset: ($touch-target-size - $checkbox-size) / 2;
+$pseudo-offset: $touch-target-size - $input-offset;
+
+.x-govuk-checkbox {
+  @include govuk-font($size: 19);
+  display: inline-block;
+  padding-left: $pseudo-offset + govuk-spacing(1);
+  position: relative;
+}
+
+.x-govuk-checkbox__input {
+  left: $input-offset * -1;
+  height: $touch-target-size;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+  top: $input-offset * -1;
+  width: $touch-target-size;
+  z-index: 1;
+}
+
+.x-govuk-checkbox__pseudo {
+  display: inline-block;
+}
+
+// [ ] Check box
+.x-govuk-checkbox__pseudo:before {
+  box-sizing: border-box;
+  content: "";
+  position: absolute;
+  top: $input-offset - $govuk-border-width-form-element;
+  left: 0;
+  width: $checkbox-size;
+  height: $checkbox-size;
+  border: $govuk-border-width-form-element solid currentColor;
+  background: transparent;
+  opacity: .5;
+}
+
+// ✔ Check mark
+//
+// Box with a border on the left and bottom side (└──), rotated 45 degrees
+.x-govuk-checkbox__pseudo:after {
+  content: "";
+  background: transparent;
+  border: solid;
+  border-top-color: transparent;
+  border-width: 0 0 3px 3px;
+  box-sizing: border-box;
+  height: 6.5px;
+  left: 6px;
+  opacity: 0;
+  position: absolute;
+  top: 8px;
+  transform: rotate(-45deg);
+  width: 12px;
+}
+
+// [✔] Checked state
+.x-govuk-checkbox__input:checked + .x-govuk-checkbox__pseudo:after {
+  opacity: .5;
+}


### PR DESCRIPTION
Marked includes support for GitHub Flavoured Markdown, which enables you to write task lists:

```markdown
1. [x] Write the press release
2. [ ] Update the website
3. [ ] Contact the media
```

This PR uses the same method of replacing checkboxes with pseudo checkboxes as used in `govuk-frontend`. This means checkboxes and their state still get announced as they would prior to this change, but now use the same design as that for small checkboxes in the GOV.UK Design System.

As this is static text, these checkboxes are (and appear) disabled, and are not focusable or interactive.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/813383/157924311-283cf2cf-0e44-4083-947f-d43923f40f80.png) | ![after](https://user-images.githubusercontent.com/813383/157924309-1642b14c-60d3-4f23-8546-d60fd5813399.png) |



