### PR TITLE
Make heading classes relative to starting class

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,19 @@ module.exports = class GovukHTMLRenderer extends Renderer {
 
   // Headings
   heading (text, level, string, slugger) {
-    // Headings can start with either `xl` or `l` size modifier
     const modifiers = [
-      ...(this.options.headingsStartWith === 'xl' ? ['xl'] : []),
+      'xl',
       'l',
-      'm'
+      'm',
+      's'
     ]
-    const modifier = modifiers[level - 1] || 's'
+
+    // Make modifiers relative to the starting heading level
+    const headingsStartWith = (modifiers.includes(this.options.headingsStartWith)) ? this.options.headingsStartWith : 'l'
+    const modifierStartIndex = modifiers.indexOf(headingsStartWith)
+
+    const modifier = modifiers[modifierStartIndex + level - 1] || 's'
+
     const id = slugger.slug(text)
     return `<h${level} class="govuk-heading-${modifier}" id="${id}">${text}</h${level}>`
   }

--- a/tests/index.mjs
+++ b/tests/index.mjs
@@ -21,12 +21,12 @@ test('Renders headings using `s` size for lower heading levels', t => {
   t.is(result, '<h1 class="govuk-heading-l" id="heading-1">Heading 1</h1><h2 class="govuk-heading-m" id="heading-2">Heading 2</h2><h3 class="govuk-heading-s" id="heading-3">Heading 3</h3><h4 class="govuk-heading-s" id="heading-4">Heading 4</h4>')
 })
 
-test('Renders heading, starting with `xl` size', t => {
+test('Renders heading classes relative to starting level', t => {
   marked.setOptions({
     headingsStartWith: 'xl'
   })
-  const result = marked('# Heading')
-  t.is(result, '<h1 class="govuk-heading-xl" id="heading">Heading</h1>')
+  const result = marked('# Heading 1\n## Heading 2\n### Heading 3\n#### Heading 4')
+  t.is(result, '<h1 class="govuk-heading-xl" id="heading-1">Heading 1</h1><h2 class="govuk-heading-l" id="heading-2">Heading 2</h2><h3 class="govuk-heading-m" id="heading-3">Heading 3</h3><h4 class="govuk-heading-s" id="heading-4">Heading 4</h4>')
 })
 
 test('Renders paragraph', t => {

--- a/tests/index.mjs
+++ b/tests/index.mjs
@@ -11,17 +11,12 @@ test('Renders blockquote', t => {
   t.is(result, '<blockquote class="govuk-inset-text govuk-!-margin-left-0"><p class="govuk-body">Blockquote</p>\n</blockquote>\n')
 })
 
-test('Renders heading', t => {
-  const result = marked('# Heading')
-  t.is(result, '<h1 class="govuk-heading-l" id="heading">Heading</h1>')
-})
-
-test('Renders headings using `s` size for lower heading levels', t => {
+test('Renders headings', t => {
   const result = marked('# Heading 1\n## Heading 2\n### Heading 3\n#### Heading 4')
   t.is(result, '<h1 class="govuk-heading-l" id="heading-1">Heading 1</h1><h2 class="govuk-heading-m" id="heading-2">Heading 2</h2><h3 class="govuk-heading-s" id="heading-3">Heading 3</h3><h4 class="govuk-heading-s" id="heading-4">Heading 4</h4>')
 })
 
-test('Renders heading classes relative to starting level', t => {
+test('Renders headings, using classes relative to given starting level', t => {
   marked.setOptions({
     headingsStartWith: 'xl'
   })


### PR DESCRIPTION
Fixes #22 

This sets the heading size modifiers to be relative to the starting modifier. So if you start with `xl`, the next sizes will be `l`, `m` and `s`.

Other details:
* Defaults to `l` if `headingsStartWith` isn't recognised.