### PR TITLE
Update marked dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ marked('# Extra large heading')
 Will output:
 
 ```html
-<h1 class="govuk-heading-xl" id="extra-large-heading">Extra large heading</h1>
+<h1 class="govuk-heading-xl">Extra large heading</h1>
 ```
 
 ## Testing

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = class GovukHTMLRenderer extends Renderer {
   }
 
   // Headings
-  heading (text, level, string, slugger) {
+  heading (text, level) {
     const modifiers = [
       'xl',
       'l',
@@ -29,8 +29,7 @@ module.exports = class GovukHTMLRenderer extends Renderer {
 
     const modifier = modifiers[modifierStartIndex + level - 1] || 's'
 
-    const id = slugger.slug(text)
-    return `<h${level} class="govuk-heading-${modifier}" id="${id}">${text}</h${level}>`
+    return `<h${level} class="govuk-heading-${modifier}">${text}</h${level}>`
   }
 
   // Paragraphs

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^11.5.0",
-        "marked": "^5.0.0"
+        "marked": "^11.0.0"
       },
       "devDependencies": {
         "np": "^9.2.0",
@@ -5587,14 +5587,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
-      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.0.1.tgz",
+      "integrity": "sha512-P4kDhFEMlvLePBPRwOcMOv6+lYUbhfbSxJFs3Jb4Qx7v6K7l+k8Dxh9CEGfRvK71tL+qIFz5y7Pe4uzt4+/A3A==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       }
     },
     "node_modules/mathml-tag-names": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "highlight.js": "^11.5.0",
-    "marked": "^5.0.0"
+    "marked": "^11.0.0"
   },
   "devDependencies": {
     "np": "^9.2.0",

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -4,9 +4,7 @@ import { marked } from 'marked'
 import GovukHTMLRenderer from '../index.js'
 
 marked.setOptions({
-  renderer: new GovukHTMLRenderer(),
-  headerIds: false,
-  mangle: false
+  renderer: new GovukHTMLRenderer()
 })
 
 test('Renders blockquote', () => {
@@ -18,7 +16,7 @@ test('Renders blockquote', () => {
 test('Renders headings', () => {
   const result = marked('# Heading 1\n## Heading 2\n### Heading 3\n#### Heading 4')
 
-  assert.equal(result, '<h1 class="govuk-heading-l" id="heading-1">Heading 1</h1><h2 class="govuk-heading-m" id="heading-2">Heading 2</h2><h3 class="govuk-heading-s" id="heading-3">Heading 3</h3><h4 class="govuk-heading-s" id="heading-4">Heading 4</h4>')
+  assert.equal(result, '<h1 class="govuk-heading-l">Heading 1</h1><h2 class="govuk-heading-m">Heading 2</h2><h3 class="govuk-heading-s">Heading 3</h3><h4 class="govuk-heading-s">Heading 4</h4>')
 })
 
 test('Renders headings, using classes relative to given starting level', () => {
@@ -26,7 +24,7 @@ test('Renders headings, using classes relative to given starting level', () => {
 
   const result = marked('# Heading 1\n## Heading 2\n### Heading 3\n#### Heading 4')
 
-  assert.equal(result, '<h1 class="govuk-heading-xl" id="heading-1">Heading 1</h1><h2 class="govuk-heading-l" id="heading-2">Heading 2</h2><h3 class="govuk-heading-m" id="heading-3">Heading 3</h3><h4 class="govuk-heading-s" id="heading-4">Heading 4</h4>')
+  assert.equal(result, '<h1 class="govuk-heading-xl">Heading 1</h1><h2 class="govuk-heading-l">Heading 2</h2><h3 class="govuk-heading-m">Heading 3</h3><h4 class="govuk-heading-s">Heading 4</h4>')
 })
 
 test('Renders paragraph', () => {
@@ -69,7 +67,7 @@ test('Renders unordered list', () => {
 test('Renders task list', () => {
   const result = marked('* [ ] Item\n* [x] Item')
 
-  assert.equal(result, '<ul class="govuk-list govuk-list--bullet"><li><span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox" disabled><span class="x-govuk-checkbox__pseudo"></span></span>Item</li>\n<li><span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox" checked disabled><span class="x-govuk-checkbox__pseudo"></span></span>Item</li>\n</ul>\n')
+  assert.equal(result, '<ul class="govuk-list govuk-list--bullet"><li><span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox" disabled><span class="x-govuk-checkbox__pseudo"></span></span> Item</li>\n<li><span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox" checked disabled><span class="x-govuk-checkbox__pseudo"></span></span> Item</li>\n</ul>\n')
 })
 
 test('Renders section break', () => {


### PR DESCRIPTION
In updating to a version of marked post v5, we can no longer depend on having built in support for heading ids. These can still be added separately via marked’s options in a consuming package.