### PR TITLE
Restore heading ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,21 +15,17 @@ module.exports = class GovukHTMLRenderer extends Renderer {
   }
 
   // Headings
-  heading (text, level) {
-    const modifiers = [
-      'xl',
-      'l',
-      'm',
-      's'
-    ]
+  heading (text, level, raw) {
+    const id = raw.toLowerCase().replace(/[^\w]+/g, '-')
 
     // Make modifiers relative to the starting heading level
+    const modifiers = ['xl', 'l', 'm', 's']
     const headingsStartWith = (modifiers.includes(this.options.headingsStartWith)) ? this.options.headingsStartWith : 'l'
     const modifierStartIndex = modifiers.indexOf(headingsStartWith)
 
     const modifier = modifiers[modifierStartIndex + level - 1] || 's'
 
-    return `<h${level} class="govuk-heading-${modifier}">${text}</h${level}>`
+    return `<h${level} class="govuk-heading-${modifier}" id="${id}">${text}</h${level}>`
   }
 
   // Paragraphs

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -16,7 +16,13 @@ test('Renders blockquote', () => {
 test('Renders headings', () => {
   const result = marked('# Heading 1\n## Heading 2\n### Heading 3\n#### Heading 4')
 
-  assert.equal(result, '<h1 class="govuk-heading-l">Heading 1</h1><h2 class="govuk-heading-m">Heading 2</h2><h3 class="govuk-heading-s">Heading 3</h3><h4 class="govuk-heading-s">Heading 4</h4>')
+  assert.equal(result, '<h1 class="govuk-heading-l" id="heading-1">Heading 1</h1><h2 class="govuk-heading-m" id="heading-2">Heading 2</h2><h3 class="govuk-heading-s" id="heading-3">Heading 3</h3><h4 class="govuk-heading-s" id="heading-4">Heading 4</h4>')
+})
+
+test('Renders heading with id', () => {
+  const result = marked('# Heading with *emphasis*')
+
+  assert.equal(result, '<h1 class="govuk-heading-l" id="heading-with-emphasis">Heading with <em>emphasis</em></h1>')
 })
 
 test('Renders headings, using classes relative to given starting level', () => {
@@ -24,7 +30,7 @@ test('Renders headings, using classes relative to given starting level', () => {
 
   const result = marked('# Heading 1\n## Heading 2\n### Heading 3\n#### Heading 4')
 
-  assert.equal(result, '<h1 class="govuk-heading-xl">Heading 1</h1><h2 class="govuk-heading-l">Heading 2</h2><h3 class="govuk-heading-m">Heading 3</h3><h4 class="govuk-heading-s">Heading 4</h4>')
+  assert.equal(result, '<h1 class="govuk-heading-xl" id="heading-1">Heading 1</h1><h2 class="govuk-heading-l" id="heading-2">Heading 2</h2><h3 class="govuk-heading-m" id="heading-3">Heading 3</h3><h4 class="govuk-heading-s" id="heading-4">Heading 4</h4>')
 })
 
 test('Renders paragraph', () => {


### PR DESCRIPTION
In #89, I said (emphasis added):

> In updating to a version of marked post v5, we can no longer depend on having built in support for heading ids. **These can still be added separately via marked’s options in a consuming package**.

Turns out, that’s not quite true. Because we are providing a renderer, this is incompatible with the `marked-gfm-heading-id` extension.

Enable `marked-gfm-heading-id` before this extension, and its `id`s will be removed.

Enable `marked-gfm-heading-id` after this extension, and our heading classes will be removed.

So let’s provide heading ids in our extension, which we can create using our own slugger. This may not be as robust as the one `marked` previously included (which used [`github-slugger`](https://www.npmjs.com/package/github-slugger) under the hood), but should cater to 99.9% of use cases.

(We might have been able to use `github-slugger`, were it not for the fact that this package exports a Common JS module for compatibility with the GOV.UK Prototype Kit.)