### PR TITLE
Adding integration with nowprototypeit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage
 node_modules/
 npm-debug.log
 .DS_Store
+.idea

--- a/now-prototype-it.config.json
+++ b/now-prototype-it.config.json
@@ -1,0 +1,28 @@
+{
+  "version-2024-03": {
+    "meta": {
+      "description": "Convert Markdown into GOV.UK Frontend-compliant HTML. It’s an extension to the marked renderer and is inspired by its Ruby equivalent gem govuk_markdown."
+    },
+    "pluginDependencies": [
+      "@nowprototypeit/govuk-frontend-adaptor"
+    ],
+    "markdownRenderers": [
+      {
+        "path": "/nowprototypeit-integration/renderer.js",
+        "name": "govuk-markdown"
+      }
+    ],
+    "templates": [
+      {
+        "path": "/nowprototypeit-integration/templates/govuk-content-page.md",
+        "name": "GOV.UK Content Page",
+        "type": "markdown"
+      },
+      {
+        "path": "/nowprototypeit-integration/templates/govuk-accordion.md",
+        "name": "GOV.UK Accordion Example",
+        "type": "markdown"
+      }
+    ]
+  }
+}

--- a/nowprototypeit-integration/renderer.js
+++ b/nowprototypeit-integration/renderer.js
@@ -1,0 +1,21 @@
+const { Marked } = require('marked')
+const govukMarkdown = require('../index')
+
+const markedWithXlHeadings = new Marked(govukMarkdown({
+  headingsStartWith: 'xl'
+}))
+
+markedWithXlHeadings.h = 'xl'
+
+const markedWithLHeadings = new Marked(govukMarkdown({
+  headingsStartWith: 'l'
+}))
+
+markedWithLHeadings.h = 'l'
+
+module.exports = {
+  markdownRenderer: function(markdown, metadata) {
+    const renderer = metadata.attributes.headingsStartWith === 'xl' ? markedWithXlHeadings : markedWithLHeadings
+    return renderer.parse(markdown)
+  }
+}

--- a/nowprototypeit-integration/templates/govuk-accordion.md
+++ b/nowprototypeit-integration/templates/govuk-accordion.md
@@ -1,0 +1,66 @@
+---
+nunjucksLayout: layouts/main.njk
+nunjucksMainBlock: content
+useRenderer: "govuk-markdown:govuk-markdown"
+processOutputAs: njk
+---
+
+# GOV.UK accordion example
+
+This example uses [the accordion component from GOV.UK Frontend](https://design-system.service.gov.uk/components/accordion/).
+
+The example uses a mix of Nunjucks and Markdown in order to use the component (which is in Nunnjucks) and to provide the content for the accordion items (which is in Markdown).
+
+{% set firstItem %}
+
+### This is the first item
+
+You can use any markdown you want in this section like **bold**, *italic*, [links](https://example.com) etc.
+
+{% endset %}
+
+{% set secondItem %}
+
+### This is the second item
+
+Enter your content here.
+
+{% endset %}
+
+{% set thirdItem %}
+
+### This is the third item
+
+Enter your content here.
+
+{% endset %}
+
+{{ govukAccordion({
+  id: "accordion-default",
+  items: [
+    {
+      heading: {
+        text: "First item"
+      },
+      content: {
+        html: firstItem
+      }
+    },
+    {
+      heading: {
+        text: "Second item"
+      },
+      content: {
+        html: secondItem
+      }
+    },
+    {
+      heading: {
+        text: "Third item"
+      },
+      content: {
+        html: thirdItem
+      }
+    }
+  ]
+}) }}

--- a/nowprototypeit-integration/templates/govuk-content-page.md
+++ b/nowprototypeit-integration/templates/govuk-content-page.md
@@ -1,0 +1,34 @@
+---
+nunjucksLayout: layouts/main.njk
+nunjucksMainBlock: content
+useRenderer: "govuk-markdown:govuk-markdown"
+processOutputAs: njk
+---
+
+# GOV.UK content page
+
+This is a paragraph [with a link](http://example.com).
+
+You can add more paragraphs with **bold**, *italic* etc.
+
+## You can include subheadings
+
+### And deeper subheadings
+
+You can include:
+
+ - bullet points
+ - **bold text** inside bullet points
+ - *italic text* inside bullet points
+
+You can also include:
+
+1. numbered lists
+2. Nunjucks variables like your service name: "{{serviceName}}"
+
+
+| Sometimes tables |      Are      | Necessary |
+|------------------|:-------------:|----------:|
+| col 3 is         | right-aligned |     $1600 |
+| col 2 is         | centered      |       $12 |
+| Col 1 is         | left-aligned  |        $1 |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   },
   "license": "MIT",
   "files": [
-    "x-govuk"
+    "x-govuk",
+    "nowprototypeit-integration",
+    "now-prototype-it.config.json"
   ],
   "main": "index.js",
   "sass": "x-govuk/all.scss",


### PR DESCRIPTION
## Background

Now Prototype It is a project I've been working on, it's an open-source, high fidelity prototype kit which is based on the GOV.UK Prototype Kit.  I've removed the GOV.UK specifics from the core of the kit and built them into an adaptor which is designed to allow any organisation to customise the kit and make it their own while still supporting the needs of UK Government departments.

I've been looking at supporting a wider range of languages from Markdown to a Node version of erb and eventually I'm hoping to get to React too.

I'm working on the Markdown part first as I think it brings a lot of benefit to the immediate potential user base.

## This PR

Like the GOV.UK Prototype Kit, Now Prototype It uses a Plugin Framework.  This PR adds the plugin configuration for:

 - Adding the nunjucks renderer
 - Detecting the starting header level on a page-by-page basis
 - Two templates for people to use as starter pages inside their prototypes

I've created a [prototype to demonstrate these changes alongside my changes in Now Prototype It](https://github.com/nataliecarey/govuk-markdown-prototype-experiment).

The simplest markdown page using this renderer and a GOV.UK Layout would be:

```
---
nunjucksLayout: govuk-frontend-adaptor/layouts/govuk-branded.njk
nunjucksMainBlock: content
useRenderer: "govuk-markdown:govuk-markdown"
---

# GOV.UK content page
```

I'm planning to allow the user to specify a default renderer on their settings pages (it currently defaults to the built-in vanilla renderer and there's no way to change the default).

## Next steps

If you like the change then I suggest you take a look at the templates, they'd probably benefit from some refining.

P.S. I've also fixed a bug with centring text which I'm happy to break out into a separate PR if that's preferred.