### PR TITLE
Use new marked renderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,39 +10,50 @@ module.exports = function (options = {}) {
   return {
     renderer: {
       // Block quotes
-      blockquote(quote) {
-        return `<blockquote class="govuk-inset-text govuk-!-margin-left-0">${quote}</blockquote>\n`
+      blockquote({ tokens }) {
+        const body = this.parser.parse(tokens)
+
+        return `<blockquote class="govuk-inset-text govuk-!-margin-left-0">${body}</blockquote>\n`
       },
 
       // Headings
-      heading(text, level, raw) {
-        const id = raw.toLowerCase().replace(/[^\w]+/g, '-')
+      heading({ tokens, depth, raw }) {
+        const text = this.parser.parseInline(tokens)
+        const id = raw
+          .toLowerCase()
+          .replace(/[^\w\s]+/g, '') // Replace all but words and spaces
+          .trim()
+          .replace(/\s/g, '-') // Replace spaces with hyphens
 
-        // Make modifiers relative to the starting heading level
+        // Make modifiers relative to the starting heading depth
         const modifiers = ['xl', 'l', 'm', 's']
         const headingsStartWith = modifiers.includes(options.headingsStartWith)
           ? options.headingsStartWith
           : 'l'
         const modifierStartIndex = modifiers.indexOf(headingsStartWith)
 
-        const modifier = modifiers[modifierStartIndex + level - 1] || 's'
+        const modifier = modifiers[modifierStartIndex + depth - 1] || 's'
 
-        return `<h${level} class="govuk-heading-${modifier}" id="${id}">${text}</h${level}>`
+        return `<h${depth} class="govuk-heading-${modifier}" id="${id}">${text}</h${depth}>`
       },
 
       // Paragraphs
-      paragraph(string) {
+      paragraph({ tokens }) {
+        const text = this.parser.parseInline(tokens)
+
         // Don’t place figure (or figure within an anchor) within paragraph
         const FIGURE_RE = /(<a([^>]+)>)?<figure/
-        if (FIGURE_RE.test(string)) {
-          return string
+        if (FIGURE_RE.test(text)) {
+          return text
         } else {
-          return `<p class="govuk-body">${string}</p>\n`
+          return `<p class="govuk-body">${text}</p>\n`
         }
       },
 
       // Links
-      link(href, title, text) {
+      link({ href, title, tokens }) {
+        const text = this.parser.parseInline(tokens)
+
         if (title) {
           return `<a class="govuk-link" href="${href}" title="${title}">${text}</a>`
         } else {
@@ -51,15 +62,21 @@ module.exports = function (options = {}) {
       },
 
       // Lists
-      list(body, ordered) {
+      list({ ordered, start, items }) {
+        let body = ''
+        for (const item in items) {
+          body += this.listitem(items[item])
+        }
+
         const element = ordered ? 'ol' : 'ul'
         const modifier = ordered ? 'number' : 'bullet'
+        const startAttr = ordered && start !== 1 ? ` start="${start}"` : ''
 
-        return `<${element} class="govuk-list govuk-list--${modifier}">${body}</${element}>\n`
+        return `<${element}${startAttr} class="govuk-list govuk-list--${modifier}">${body}</${element}>\n`
       },
 
       // Checkbox
-      checkbox(checked) {
+      checkbox({ checked }) {
         return `<span class="x-govuk-checkbox"><input class="x-govuk-checkbox__input" type="checkbox"${
           checked ? ' checked' : ''
         } disabled><span class="x-govuk-checkbox__pseudo"></span></span>`
@@ -71,44 +88,69 @@ module.exports = function (options = {}) {
       },
 
       // Tables
-      table(header, body) {
-        return `<table class="govuk-table">\n<thead class="govuk-table__head">\n${header}</thead>\n<tbody class="govuk-table__body">${body}</tbody>\n</table>\n`
+      table({ header, rows }) {
+        // Table head
+        let head = ''
+        let text = ''
+        for (const cell in header) {
+          text += this.tablecell(header[cell])
+        }
+        head += this.tablerow({ text })
+
+        // Table body
+        let body = ''
+        for (let row in rows) {
+          row = rows[row]
+          text = ''
+          for (const cell in row) {
+            text += this.tablecell(row[cell])
+          }
+          body += this.tablerow({ text })
+        }
+
+        if (body) {
+          body = `<tbody class="govuk-table__body">${body}</tbody>\n`
+        }
+
+        return `<table class="govuk-table">\n<thead class="govuk-table__head">\n${head}</thead>\n${body}</table>\n`
       },
 
-      tablerow(content) {
-        return `<tr class="govuk-table__row">\n${content}</tr>\n`
+      tablerow({ text }) {
+        return `<tr class="govuk-table__row">\n${text}</tr>\n`
       },
 
-      tablecell(content, { header, align }) {
+      tablecell({ tokens, header, align }) {
+        const text = this.parser.parseInline(tokens)
         const element = header ? 'th' : 'td'
         const className = header ? 'govuk-table__header' : 'govuk-table__cell'
         const alignClass = align ? ` govuk-!-text-align-${align}` : ''
-        return `<${element} class="${className}${alignClass}">${content}</${element}>\n`
+
+        return `<${element} class="${className}${alignClass}">${text}</${element}>\n`
       },
 
       // Block code
       // By not using marked’s `highlight` option, we can add a class to the container
-      code(string, language) {
+      code({ text, lang: language }) {
         highlightJs.configure({ classPrefix: 'x-govuk-code__' })
 
         if (language) {
           // Code language has been set, or can be determined
           let code
           if (highlightJs.getLanguage(language)) {
-            code = highlightJs.highlight(string, { language }).value
+            code = highlightJs.highlight(text, { language }).value
           } else {
-            code = highlightJs.highlightAuto(string).value
+            code = highlightJs.highlightAuto(text).value
           }
           return `<pre class="x-govuk-code x-govuk-code--block x-govuk-code__language--${language}" tabindex="0"><code>${code}</code></pre>\n`
         } else {
           // No language found, so render as plain text
-          return `<pre class="x-govuk-code x-govuk-code--block" tabindex="0">${string}</pre>\n`
+          return `<pre class="x-govuk-code x-govuk-code--block" tabindex="0">${text}</pre>\n`
         }
       },
 
       // Inline code
-      codespan(code) {
-        return `<code class="x-govuk-code x-govuk-code--inline">${code}</code>`
+      codespan({ text }) {
+        return `<code class="x-govuk-code x-govuk-code--inline">${text}</code>`
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^11.5.0",
-        "marked": "^12.0.0"
+        "marked": "^14.0.0"
       },
       "devDependencies": {
         "eslint": "^8.55.0",
@@ -5133,9 +5133,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.1.tgz",
+      "integrity": "sha512-eS59oxof5eBVDCKTs+mJbvB/6Vq137GbimF9wkTIlto2/B2ppY5nigUUQgKVmA3bI2mPTIshUyDj5j612ZxlQQ==",
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "highlight.js": "^11.5.0",
-    "marked": "^12.0.0"
+    "marked": "^14.0.0"
   },
   "devDependencies": {
     "eslint": "^8.55.0",


### PR DESCRIPTION
In v13, marked introduced [a new renderer](https://github.com/markedjs/marked/releases/tag/v13.0.0). In v14, this replaced the old renderer, which was removed.

This PR updates the rendering methods to use [the new renderer API](https://marked.js.org/using_pro#renderer), and will be released in a BREAKING pre-release. 